### PR TITLE
LanguageConfiguration: expose most helpers

### DIFF
--- a/Sources/CodeEditorView/GutterView.swift
+++ b/Sources/CodeEditorView/GutterView.swift
@@ -146,7 +146,6 @@ extension GutterView {
   /// breaks.
   ///
   func invalidateGutter(forCharRange charRange: NSRange) {
-    return
     
     let string        = textView.text as NSString,
         safeCharRange = NSIntersectionRange(charRange, NSRange(location: 0, length: string.length))
@@ -270,6 +269,9 @@ extension GutterView {
                                     .foregroundColor: theme.textColour,
                                     .paragraphStyle: lineNumberStyle,
                                     .kern: NSNumber(value: Float(-theme.fontSize / 11))]
+
+      // TODO: CodeEditor needs to be parameterised by message theme
+      let theme = Message.defaultTheme
 
       for line in lineRange {
 

--- a/Sources/CodeEditorView/LanguageConfiguration.swift
+++ b/Sources/CodeEditorView/LanguageConfiguration.swift
@@ -131,6 +131,23 @@ public struct LanguageConfiguration {
   ///
   public let reservedIdentifiers: [String]
 
+  public init(stringRegexp: String?,
+              characterRegexp: String?,
+              numberRegexp: String?,
+              singleLineComment: String?,
+              nestedComment: LanguageConfiguration.BracketPair?,
+              identifierRegexp: String?,
+              reservedIdentifiers: [String])
+  {
+    self.stringRegexp         = stringRegexp
+    self.characterRegexp      = characterRegexp
+    self.numberRegexp         = numberRegexp
+    self.singleLineComment    = singleLineComment
+    self.nestedComment        = nestedComment
+    self.identifierRegexp     = identifierRegexp
+    self.reservedIdentifiers  = reservedIdentifiers
+  }
+
   /// Yields the lexeme of the given token under this language configuration if the token has got a unique lexeme.
   ///
   func lexeme(of token: Token) -> String? {

--- a/Sources/CodeEditorView/LanguageConfiguration.swift
+++ b/Sources/CodeEditorView/LanguageConfiguration.swift
@@ -167,41 +167,51 @@ extension LanguageConfiguration {
 
 }
 
-// Helpers
-private let binary    = "(?:[01]_*)+"
-private let octal     = "(?:[0-7]_*)+"
-private let decimal   = "(?:[0-9]_*)+"
-private let hexal     = "(?:[0-9A-Fa-f]_*)+"
-private let optNeg    = "(?:\\B-|\\b)"
-private let exponent  = "[eE](?:[+-])?" + decimal
-private let hexponent = "[pP](?:[+-])?" + decimal
+extension LanguageConfiguration {
 
-private let idHeadChar   // from the Swift 5.4 reference
-  = "["
-  + "[a-zA-Z_]"
-  + "[\u{00A8}\u{00AA}\u{00AD}\u{00AF}\u{00B2}–\u{00B5}\u{00B7}–\u{00BA}]"
-  + "[\u{00BC}–\u{00BE}\u{00C0}–\u{00D6}\u{00D8}–\u{00F6}\u{00F8}–\u{00FF}]"
-  + "[\u{0100}–\u{02FF}\u{0370}–\u{167F}\u{1681}–\u{180D}\u{180F}–\u{1DBF}]"
-  + "[\u{1E00}–\u{1FFF}]"
-  + "[\u{200B}–\u{200D}\u{202A}–\u{202E}\u{203F}–\u{2040}\u{2054}\u{2060}–\u{206F}]"
-  + "[\u{2070}–\u{20CF}\u{2100}–\u{218F}\u{2460}–\u{24FF}\u{2776}–\u{2793}]"
-  + "[\u{2C00}–\u{2DFF}\u{2E80}–\u{2FFF}]"
-  + "[\u{3004}–\u{3007}\u{3021}–\u{302F}\u{3031}–\u{303F}\u{3040}–\u{D7FF}]"
-  + "[\u{F900}–\u{FD3D}\u{FD40}–\u{FDCF}\u{FDF0}–\u{FE1F}\u{FE30}–\u{FE44}]"
-  + "[\u{FE47}–\u{FFFD}]"
-  + "[\u{10000}–\u{1FFFD}\u{20000}–\u{2FFFD}\u{30000}–\u{3FFFD}\u{40000}–\u{4FFFD}]"
-  + "[\u{50000}–\u{5FFFD}\u{60000}–\u{6FFFD}\u{70000}–\u{7FFFD}\u{80000}–\u{8FFFD}]"
-  + "[\u{90000}–\u{9FFFD}\u{A0000}–\u{AFFFD}\u{B0000}–\u{BFFFD}\u{C0000}–\u{CFFFD}]"
-  + "[\u{D0000}–\u{DFFFD}\u{E0000}–\u{EFFFD}]"
-  + "]"
-private let idBodyChar   // from the Swift 5.4 reference
-  = "["
-  + "[0-9]"
-  + "[\u{0300}–\u{036F}\u{1DC0}–\u{1DFF}\u{20D0}–\u{20FF}\u{FE20}–\u{FE2F}]"
-  + "]"
+  // General purpose numeric literals
+  public static let binaryLit    = "(?:[01]_*)+"
+  public static let octalLit     = "(?:[0-7]_*)+"
+  public static let decimalLit   = "(?:[0-9]_*)+"
+  public static let hexalLit     = "(?:[0-9A-Fa-f]_*)+"
+  public static let optNegation  = "(?:\\B-|\\b)"
+  public static let exponentLit  = "[eE](?:[+-])?" + decimalLit
+  public static let hexponentLit = "[pP](?:[+-])?" + decimalLit
 
-private func group(_ regexp: String) -> String { "(?:" + regexp + ")" }
-private func alternatives(_ alts: [String]) -> String { alts.map{ group($0) }.joined(separator: "|") }
+  // Identifier components following the Swift 5.4 reference
+  public static let identifierHeadCharSwift
+    = "["
+    + "[a-zA-Z_]"
+    + "[\u{00A8}\u{00AA}\u{00AD}\u{00AF}\u{00B2}–\u{00B5}\u{00B7}–\u{00BA}]"
+    + "[\u{00BC}–\u{00BE}\u{00C0}–\u{00D6}\u{00D8}–\u{00F6}\u{00F8}–\u{00FF}]"
+    + "[\u{0100}–\u{02FF}\u{0370}–\u{167F}\u{1681}–\u{180D}\u{180F}–\u{1DBF}]"
+    + "[\u{1E00}–\u{1FFF}]"
+    + "[\u{200B}–\u{200D}\u{202A}–\u{202E}\u{203F}–\u{2040}\u{2054}\u{2060}–\u{206F}]"
+    + "[\u{2070}–\u{20CF}\u{2100}–\u{218F}\u{2460}–\u{24FF}\u{2776}–\u{2793}]"
+    + "[\u{2C00}–\u{2DFF}\u{2E80}–\u{2FFF}]"
+    + "[\u{3004}–\u{3007}\u{3021}–\u{302F}\u{3031}–\u{303F}\u{3040}–\u{D7FF}]"
+    + "[\u{F900}–\u{FD3D}\u{FD40}–\u{FDCF}\u{FDF0}–\u{FE1F}\u{FE30}–\u{FE44}]"
+    + "[\u{FE47}–\u{FFFD}]"
+    + "[\u{10000}–\u{1FFFD}\u{20000}–\u{2FFFD}\u{30000}–\u{3FFFD}\u{40000}–\u{4FFFD}]"
+    + "[\u{50000}–\u{5FFFD}\u{60000}–\u{6FFFD}\u{70000}–\u{7FFFD}\u{80000}–\u{8FFFD}]"
+    + "[\u{90000}–\u{9FFFD}\u{A0000}–\u{AFFFD}\u{B0000}–\u{BFFFD}\u{C0000}–\u{CFFFD}]"
+    + "[\u{D0000}–\u{DFFFD}\u{E0000}–\u{EFFFD}]"
+    + "]"
+  public static let identifierBodyCharSwift
+    = "["
+    + "[0-9]"
+    + "[\u{0300}–\u{036F}\u{1DC0}–\u{1DFF}\u{20D0}–\u{20FF}\u{FE20}–\u{FE2F}]"
+    + "]"
+
+  /// Wrap a regular expression into grouping brackets.
+  ///
+  public static func group(_ regexp: String) -> String { "(?:" + regexp + ")" }
+
+  /// COmpose an array of regular expressions as alternatives.
+  ///
+  public static func alternatives(_ alts: [String]) -> String { alts.map{ group($0) }.joined(separator: "|") }
+}
+
 
 private let haskellReservedIds =
   ["case", "class", "data", "default", "deriving", "do", "else", "foreign", "if", "import", "in", "infix", "infixl",
@@ -214,23 +224,23 @@ extension LanguageConfiguration {
   public static let haskell = LanguageConfiguration(stringRegexp: "\"(?:\\\\\"|[^\"])*+\"",
                                                     characterRegexp: "'(?:\\\\'|[^']|\\\\[^']*+)'",
                                                     numberRegexp:
-                                                      optNeg +
+                                                      optNegation +
                                                       group(alternatives([
-                                                        "0[bB]" + binary,
-                                                        "0[oO]" + octal,
-                                                        "0[xX]" + hexal,
-                                                        "0[xX]" + hexal + "\\." + hexal + hexponent + "?",
-                                                        decimal + "\\." + decimal + exponent + "?",
-                                                        decimal + exponent,
-                                                        decimal
+                                                        "0[bB]" + binaryLit,
+                                                        "0[oO]" + octalLit,
+                                                        "0[xX]" + hexalLit,
+                                                        "0[xX]" + hexalLit + "\\." + hexalLit + hexponentLit + "?",
+                                                        decimalLit + "\\." + decimalLit + exponentLit + "?",
+                                                        decimalLit + exponentLit,
+                                                        decimalLit
                                                       ])),
                                                     singleLineComment: "--",
                                                     nestedComment: (open: "{-", close: "-}"),
                                                     identifierRegexp:
-                                                      idHeadChar +
+                                                      identifierHeadCharSwift +
                                                       group(alternatives([
-                                                        idHeadChar,
-                                                        idBodyChar,
+                                                        identifierHeadCharSwift,
+                                                        identifierBodyCharSwift,
                                                         "'"
                                                       ])) + "*",
                                                     reservedIdentifiers: haskellReservedIds)
@@ -251,35 +261,35 @@ extension LanguageConfiguration {
   public static let swift = LanguageConfiguration(stringRegexp: "\"(?:\\\\\"|[^\"])*+\"",
                                                   characterRegexp: nil,
                                                   numberRegexp:
-                                                    optNeg +
+                                                    optNegation +
                                                     group(alternatives([
-                                                      "0b" + binary,
-                                                      "0o" + octal,
-                                                      "0x" + hexal,
-                                                      "0x" + hexal + "\\." + hexal + hexponent + "?",
-                                                      decimal + "\\." + decimal + exponent + "?",
-                                                      decimal + exponent,
-                                                      decimal
+                                                      "0b" + binaryLit,
+                                                      "0o" + octalLit,
+                                                      "0x" + hexalLit,
+                                                      "0x" + hexalLit + "\\." + hexalLit + hexponentLit + "?",
+                                                      decimalLit + "\\." + decimalLit + exponentLit + "?",
+                                                      decimalLit + exponentLit,
+                                                      decimalLit
                                                     ])),
                                                   singleLineComment: "//",
                                                   nestedComment: (open: "/*", close: "*/"),
                                                   identifierRegexp:
                                                     alternatives([
-                                                      idHeadChar +
+                                                      identifierHeadCharSwift +
                                                         group(alternatives([
-                                                          idHeadChar,
-                                                          idBodyChar,
+                                                          identifierHeadCharSwift,
+                                                          identifierBodyCharSwift,
                                                         ])) + "*",
-                                                      "`" + idHeadChar +
+                                                      "`" + identifierHeadCharSwift +
                                                         group(alternatives([
-                                                          idHeadChar,
-                                                          idBodyChar,
+                                                          identifierHeadCharSwift,
+                                                          identifierBodyCharSwift,
                                                         ])) + "*`",
-                                                      "\\\\$" + decimal,
-                                                      "\\\\$" + idHeadChar +
+                                                      "\\\\$" + decimalLit,
+                                                      "\\\\$" + identifierHeadCharSwift +
                                                         group(alternatives([
-                                                          idHeadChar,
-                                                          idBodyChar,
+                                                          identifierHeadCharSwift,
+                                                          identifierBodyCharSwift,
                                                         ])) + "*"
                                                     ]),
                                                   reservedIdentifiers: swiftReservedIds)


### PR DESCRIPTION
They get scoped and slightly more expressive names. (The names are still partially abbreviated; otherwise, the regular expressions just get too big, negatively affecting readability.)