### PR TITLE
Case insensitive identifiers

### DIFF
--- a/Sources/CodeEditorView/CodeStorageDelegate.swift
+++ b/Sources/CodeEditorView/CodeStorageDelegate.swift
@@ -180,7 +180,8 @@ class CodeStorageDelegate: NSObject, NSTextStorageDelegate {
 
   init(with language: LanguageConfiguration, setText: @escaping (String) -> Void) {
     self.language  = language
-    self.tokeniser = Tokeniser(for: language.tokenDictionary)
+    self.tokeniser = Tokeniser(for: language.tokenDictionary,
+                               caseInsensitiveReservedIdentifiers: language.caseInsensitiveReservedIdentifiers)
     self.setText   = setText
     super.init()
   }
@@ -211,7 +212,8 @@ class CodeStorageDelegate: NSObject, NSTextStorageDelegate {
     // If the actual language changes and not just the language service, re-tokenise the code storage.
     if currentLanguage.name != language.name {
 
-      self.tokeniser = Tokeniser(for: language.tokenDictionary)
+      self.tokeniser = Tokeniser(for: language.tokenDictionary,
+                                 caseInsensitiveReservedIdentifiers: language.caseInsensitiveReservedIdentifiers)
       let _ = tokenise(range: NSRange(location: 0, length: codeStorage.length), in: codeStorage)
 
     }

--- a/Sources/LanguageSupport/LanguageConfiguration.swift
+++ b/Sources/LanguageSupport/LanguageConfiguration.swift
@@ -482,7 +482,7 @@ extension LanguageConfiguration {
     if supportsCurlyBrackets {
       codeTokens.append(contentsOf:
                           [ TokenDescription(regex: /{/, singleLexeme: "{", action: token(.curlyBracketOpen))
-                          , TokenDescription(regex: /}/, singleLexeme: "}", action: token(.squareBracketClose))
+                          , TokenDescription(regex: /}/, singleLexeme: "}", action: token(.curlyBracketClose))
                           ])
     }
     if let regex = stringRegex { codeTokens.append(TokenDescription(regex: regex, action: token(.string))) }

--- a/Sources/LanguageSupport/LanguageConfiguration.swift
+++ b/Sources/LanguageSupport/LanguageConfiguration.swift
@@ -174,6 +174,10 @@ public struct LanguageConfiguration {
   ///
   public let supportsCurlyBrackets: Bool
 
+  /// Whether reserved identifiers are case-sensitive.
+  ///
+  public let caseInsensitiveReservedIdentifiers: Bool
+
   /// Regular expression matching strings
   ///
   public let stringRegex: Regex<Substring>?
@@ -219,6 +223,7 @@ public struct LanguageConfiguration {
   public init(name: String,
               supportsSquareBrackets: Bool,
               supportsCurlyBrackets: Bool,
+              caseInsensitiveReservedIdentifiers: Bool = false,
               stringRegex: Regex<Substring>?,
               characterRegex: Regex<Substring>?,
               numberRegex: Regex<Substring>?,
@@ -233,6 +238,7 @@ public struct LanguageConfiguration {
     self.name                   = name
     self.supportsSquareBrackets = supportsSquareBrackets
     self.supportsCurlyBrackets  = supportsCurlyBrackets
+    self.caseInsensitiveReservedIdentifiers = caseInsensitiveReservedIdentifiers
     self.stringRegex            = stringRegex
     self.characterRegex         = characterRegex
     self.numberRegex            = numberRegex
@@ -504,7 +510,8 @@ extension LanguageConfiguration {
     if let regex = identifierRegex { codeTokens.append(TokenDescription(regex: regex, action: token(.identifier(nil)))) }
     if let regex = operatorRegex { codeTokens.append(TokenDescription(regex: regex, action: token(.operator(nil)))) }
     for reserved in reservedIdentifiers {
-      codeTokens.append(TokenDescription(regex: Regex{ Anchor.wordBoundary; reserved; Anchor.wordBoundary },
+      let regex = Regex{ Anchor.wordBoundary; reserved; Anchor.wordBoundary }.ignoresCase(caseInsensitiveReservedIdentifiers)
+      codeTokens.append(TokenDescription(regex: regex,
                                          singleLexeme: reserved,
                                          action: token(.keyword)))
     }


### PR DESCRIPTION
As discussed in #112, adds support for case-insensitive reserved identifiers.

Also fixes "}" being recognised as a closing square bracket.

Because this change needs coordinating between the tokeniser and the language configuration, both parts need to be aware of the new option. To do this, I've added the option flag to both types, both defaulting to false to avoid breaking existing uses.

I've not finished the SQLite language config yet, but this seems to be enough to allow it to work.