### PR TITLE
Add support for Cypher language

### DIFF
--- a/Sources/LanguageSupport/CypherConfiguration.swift
+++ b/Sources/LanguageSupport/CypherConfiguration.swift
@@ -1,0 +1,191 @@
+//
+//  CypherConfiguration.swift
+//
+//
+//  Created by Carlo Rapisarda on 2024-12-21.
+//
+
+import Foundation
+import RegexBuilder
+
+extension LanguageConfiguration {
+    
+    public static func cypher(_ languageService: LanguageService? = nil) -> LanguageConfiguration {
+        
+        // Number Regex
+        // Optional + or -, then digits, optional decimal, optional exponent
+        let numberRegex: Regex<Substring> = Regex {
+            Optionally {
+                ChoiceOf {
+                    "+"
+                    "-"
+                }
+            }
+            OneOrMore(.digit)
+            Optionally {
+                "."
+                OneOrMore(.digit)
+            }
+            Optionally {
+                ChoiceOf {
+                    "e"
+                    "E"
+                }
+                Optionally {
+                    ChoiceOf {
+                        "+"
+                        "-"
+                    }
+                }
+                OneOrMore(.digit)
+            }
+        }
+        
+        // Identifier Regex
+        // Plain identifiers: start with letter or underscore, then letters, digits, underscores
+        let alphaOrUnderscore = ChoiceOf {
+            "a"..."z"
+            "A"..."Z"
+            "_"
+        }
+        let alphaNumOrUnderscore = ChoiceOf {
+            "a"..."z"
+            "A"..."Z"
+            "0"..."9"
+            "_"
+        }
+        
+        // Plain (unquoted) identifier
+        let plainIdentifierRegex: Regex<Substring> = Regex {
+            alphaOrUnderscore
+            ZeroOrMore {
+                alphaNumOrUnderscore
+            }
+        }
+        
+        // Backtick-quoted identifier: everything except backticks
+        let quotedIdentifierRegex: Regex<Substring> = Regex {
+            "`"
+            ZeroOrMore {
+                NegativeLookahead {
+                    "`"
+                }
+                // Match any character that is not a backtick
+                CharacterClass.any
+            }
+            "`"
+        }
+        
+        // Combine both unquoted and backtick-quoted
+        let identifierRegex: Regex<Substring> = Regex {
+            ChoiceOf {
+                plainIdentifierRegex
+                quotedIdentifierRegex
+            }
+        }
+        
+        // String Regex (single or double quoted, with doubled quotes to escape)
+        // Single-quoted strings
+        let singleQuotedString: Regex<Substring> = Regex {
+            "'"
+            ZeroOrMore {
+                ChoiceOf {
+                    // Two single-quotes in a row => escaped quote
+                    Regex {
+                        "'"
+                        "'"
+                    }
+                    // Otherwise, any character except a single quote
+                    Regex {
+                        NegativeLookahead { "'" }
+                        CharacterClass.any
+                    }
+                }
+            }
+            "'"
+        }
+        
+        // Double-quoted strings
+        let doubleQuotedString: Regex<Substring> = Regex {
+            "\""
+            ZeroOrMore {
+                ChoiceOf {
+                    // Two double-quotes in a row => escaped quote
+                    Regex {
+                        "\""
+                        "\""
+                    }
+                    // Otherwise, any character except a double quote
+                    Regex {
+                        NegativeLookahead { "\"" }
+                        CharacterClass.any
+                    }
+                }
+            }
+            "\""
+        }
+        
+        // Combine single-quoted or double-quoted into one string pattern
+        let cypherStringRegex: Regex<Substring> = Regex {
+            ChoiceOf {
+                singleQuotedString
+                doubleQuotedString
+            }
+        }
+        
+        // Comment Syntax
+        // Single-line: "//", nested: /* ... */
+        let singleLineComment = "//"
+        let nestedComment = (open: "/*", close: "*/")
+        
+        // Keywords (case-insensitive)
+        let cypherReservedIdentifiers = [
+            "all", "alter", "and", "as", "asc", "ascending",
+            "by", "call", "case", "commit", "contains", "create",
+            "delete", "desc", "descending", "detach", "distinct", "drop",
+            "else", "end", "ends", "exists", "false", "fieldterminator",
+            "filter", "in", "is", "limit", "load", "csv", "match",
+            "merge", "not", "null", "on", "optional", "or", "order",
+            "remove", "return", "skip", "start", "then", "true", "union",
+            "unique", "unwind", "using", "when", "where", "with", "xor"
+        ]
+        
+        // Operator Regex
+        // We highlight multi-char and single-char operators.
+        let operatorRegex: Regex<Substring> = Regex {
+            ChoiceOf {
+                "<>"
+                "<="
+                ">="
+                "=~"
+                "="
+                "<"
+                ">"
+                "+"
+                "-"
+                "*"
+                "/"
+                "%"
+                "^"
+                "!"
+            }
+        }
+        
+        return LanguageConfiguration(
+            name: "Cypher",
+            supportsSquareBrackets: true,
+            supportsCurlyBrackets: true,
+            caseInsensitiveReservedIdentifiers: true,
+            stringRegex: cypherStringRegex,
+            characterRegex: nil,
+            numberRegex: numberRegex,
+            singleLineComment: singleLineComment,
+            nestedComment: nestedComment,
+            identifierRegex: identifierRegex,
+            operatorRegex: operatorRegex,
+            reservedIdentifiers: cypherReservedIdentifiers,
+            reservedOperators: [],
+            languageService: languageService
+        )
+    }
+}

--- a/Tests/CodeEditorTests/CypherConfigurationTests.swift
+++ b/Tests/CodeEditorTests/CypherConfigurationTests.swift
@@ -1,0 +1,158 @@
+//
+//  CypherConfigurationTests.swift
+//
+//
+//  Created by Carlo Rapisarda on 2024-12-22.
+//
+
+import Foundation
+import RegexBuilder
+import Testing
+@testable import CodeEditorView
+@testable import LanguageSupport
+
+struct CypherNumberTokenisingTests {
+  
+  let codeStorage: CodeStorage
+  let codeStorageDelegate: CodeStorageDelegate
+  
+  init() {
+    codeStorageDelegate = CodeStorageDelegate(with: .cypher(), setText: { _ in })
+    codeStorage = CodeStorage(theme: .defaultLight)
+    codeStorage.delegate = codeStorageDelegate
+  }
+  
+  @Test("Recognises valid numbers", arguments: validNumbers)
+  func tokenisesAsNumber(number: String) throws {
+    let attributedString = NSAttributedString(string: number)
+    codeStorage.setAttributedString(attributedString)  // triggers tokenisation
+    let lineMap = codeStorageDelegate.lineMap
+    
+    #expect(lineMap.lines.count == 1)
+
+    let tokens = try #require(lineMap.lookup(line: 0)?.info?.tokens, "A token should be found")
+    #expect(tokens.count == 1, "A single token should be found")
+    
+    let expectedToken = Tokeniser<LanguageConfiguration.Token, LanguageConfiguration.State>.Token(
+      token: .number,
+      range: NSRange(location: 0, length: attributedString.length)
+    )
+    #expect(tokens.first == expectedToken)
+  }
+  
+  /// A few examples of numeric literals that should be valid in Cypher:
+  private static var validNumbers: [String] = [
+    "42",
+    "-42",
+    "3.14159",
+    "0.5",
+    "-0.5",
+    "123.456e2",
+    "-2.5E-3",
+    "1E+6"
+  ]
+}
+
+struct CypherIdentifierTokenisingTests {
+  
+  let codeStorage: CodeStorage
+  let codeStorageDelegate: CodeStorageDelegate
+  
+  init() {
+    codeStorageDelegate = CodeStorageDelegate(with: .cypher(), setText: { _ in })
+    codeStorage = CodeStorage(theme: .defaultLight)
+    codeStorage.delegate = codeStorageDelegate
+  }
+  
+  @Test("Recognises valid identifiers", arguments: validIdentifiers)
+  func tokenisesAsIdentifier(text: String) throws {
+    let attributedStringValue = NSAttributedString(string: text)
+    codeStorage.setAttributedString(attributedStringValue)  // triggers tokenisation
+    let lineMap = codeStorageDelegate.lineMap
+    
+    #expect(lineMap.lines.count == 1)
+    
+    let tokens = try #require(lineMap.lookup(line: 0)?.info?.tokens, "A token should be found")
+    #expect(tokens.count == 1, "A single token should be found")
+    
+    let expectedToken = Tokeniser<LanguageConfiguration.Token, LanguageConfiguration.State>.Token(
+      token: .identifier(nil),
+      range: NSRange(location: 0, length: attributedStringValue.length)
+    )
+    #expect(tokens.first == expectedToken)
+  }
+  
+  @Test("Recognises invalid identifiers", arguments: invalidIdentifiers)
+  func tokenisesAsNonIdentifier(text: String) throws {
+    let attributedStringValue = NSAttributedString(string: text)
+    codeStorage.setAttributedString(attributedStringValue)  // triggers tokenisation
+    let lineMap = codeStorageDelegate.lineMap
+    
+    #expect(lineMap.lines.count == 1)
+    
+    let tokens = try #require(lineMap.lookup(line: 0)?.info?.tokens, "Tokens should be found")
+    #expect(tokens.count > 1, "Multiple tokens should be found if it's not a single valid identifier.")
+  }
+  
+  /// Valid Cypher identifiers:
+  ///  - Unquoted: start with letter or underscore, followed by letters, digits, underscores
+  ///  - Backtick-quoted: can contain more varied characters
+  private static var validIdentifiers: [String] = [
+    "n",
+    "_node",
+    "abc123",
+    "my_label",
+    "`some weird stuff`",
+    "`Person:Label`",
+    "`some backtick: literal with !@#$%^&*()`",
+  ]
+  
+  /// Some invalid identifier examples (leading digit, invalid symbol, etc.)
+  private static var invalidIdentifiers: [String] = [
+    "1abc",        // leading digit
+    "node!",       // exclamation mark outside backticks
+    "my-node"      // hyphen not allowed in unquoted
+  ]
+}
+
+struct CypherStringTokenisingTests {
+  
+  let codeStorage: CodeStorage
+  let codeStorageDelegate: CodeStorageDelegate
+  
+  init() {
+    codeStorageDelegate = CodeStorageDelegate(with: .cypher(), setText: { _ in })
+    codeStorage = CodeStorage(theme: .defaultLight)
+    codeStorage.delegate = codeStorageDelegate
+  }
+  
+  @Test("Recognises valid strings", arguments: validStrings)
+  func tokenisesAsString(text: String) throws {
+    let attributedStringValue = NSAttributedString(string: text)
+    codeStorage.setAttributedString(attributedStringValue)  // triggers tokenisation
+    let lineMap = codeStorageDelegate.lineMap
+    
+    #expect(lineMap.lines.count == 1)
+    
+    let tokens = try #require(lineMap.lookup(line: 0)?.info?.tokens, "A token should be found")
+    #expect(tokens.count == 1, "A single token should be found")
+    
+    let expectedToken = Tokeniser<LanguageConfiguration.Token, LanguageConfiguration.State>.Token(
+      token: .string,
+      range: NSRange(location: 0, length: attributedStringValue.length)
+    )
+    #expect(tokens.first == expectedToken)
+  }
+  
+  /// Cypher strings can be single-quoted or double-quoted, with doubling of quotes to escape:
+  private static var validStrings: [String] = [
+    "''",                // empty string in single quotes
+    "'Hello World'",
+    "'It''s a string'",  // embedded single quote
+    "\"\"",
+    "\"Hello World\"",
+    "\"Double \"\"quote\"\" example\"",
+    "'A \"nested\" example with single quotes'",
+    "\"A 'nested' example with double quotes\"",
+  ]
+}


### PR DESCRIPTION
This PR adds syntax highlighting support for the Cypher language (for Neo4j graph databases), including tests.