### PR TITLE
Support older SwiftUI module

### DIFF
--- a/Sources/CodeEditorView/CodeEditor.swift
+++ b/Sources/CodeEditorView/CodeEditor.swift
@@ -237,10 +237,24 @@ extension CodeEditor {
   }
 }
 
+#if canImport(SwiftUI, _version: 6)
 extension EnvironmentValues {
 
   @Entry public var codeEditorLayoutConfiguration: CodeEditor.LayoutConfiguration = .standard
 }
+#else
+public struct CodeEditorLayoutConfiguration: EnvironmentKey {
+  public static var defaultValue: CodeEditor.LayoutConfiguration = .standard
+}
+
+extension EnvironmentValues {
+
+  public var codeEditorLayoutConfiguration: CodeEditor.LayoutConfiguration {
+    get { self[CodeEditorLayoutConfiguration.self] }
+    set { self[CodeEditorLayoutConfiguration.self] = newValue }
+  }
+}
+#endif
 
 
 // MARK: Indentation configuration
@@ -346,10 +360,24 @@ extension CodeEditor {
   }
 }
 
+#if canImport(SwiftUI, _version: 6)
 extension EnvironmentValues {
 
   @Entry public var codeEditorIndentationConfiguration: CodeEditor.IndentationConfiguration = .standard
 }
+#else
+public struct CodeEditorIndentationConfiguration: EnvironmentKey {
+  public static var defaultValue: CodeEditor.IndentationConfiguration = .standard
+}
+
+extension EnvironmentValues {
+
+  public var codeEditorIndentationConfiguration: CodeEditor.IndentationConfiguration {
+    get { self[CodeEditorIndentationConfiguration.self] }
+    set { self[CodeEditorIndentationConfiguration.self] = newValue }
+  }
+}
+#endif
 
 
 // MARK: Code actions
@@ -402,10 +430,24 @@ extension CodeEditor {
   }
 }
 
+#if canImport(SwiftUI, _version: 6)
 extension EnvironmentValues {
 
   @Entry public var codeEditorSetActions: CodeEditor.SetActions = .ignore
 }
+#else
+public struct CodeEditorSetActions: EnvironmentKey {
+  public static var defaultValue: CodeEditor.SetActions = .ignore
+}
+
+extension EnvironmentValues {
+
+  public var codeEditorSetActions: CodeEditor.SetActions {
+    get { self[CodeEditorSetActions.self] }
+    set { self[CodeEditorSetActions.self] = newValue }
+  }
+}
+#endif
 
 
 // MARK: Editor state information
@@ -495,10 +537,24 @@ extension CodeEditor {
   }
 }
 
+#if canImport(SwiftUI, _version: 6)
 extension EnvironmentValues {
 
   @Entry public var codeEditorSetInfo: CodeEditor.SetInfo = .ignore
 }
+#else
+public struct CodeEditorSetInfo: EnvironmentKey {
+  public static var defaultValue: CodeEditor.SetInfo = .ignore
+}
+
+extension EnvironmentValues {
+
+  public var codeEditorSetInfo: CodeEditor.SetInfo {
+    get { self[CodeEditorSetInfo.self] }
+    set { self[CodeEditorSetInfo.self] = newValue }
+  }
+}
+#endif
 
 
 #if os(iOS) || os(visionOS)


### PR DESCRIPTION
`@Entry` macro is supported by SwiftUI 6 and later, but SwiftUI 6 is only available in Xcode 16 and later.

Therefore, CodeEditorView currently cannot be built with Xcode 15 or the Swift Playgrounds app. In particular, there is no workaround for the Swift Playgrounds app, since the latest version still doesn't bundle SwiftUI 6 (iOS 18 SDK).

So, if possible, could you please add a compile-time branch that would allow CodeEditorView to build with SwiftUI 5.x successfully?

I've tested this PR with Swift Playgrounds 4.5.1 on iPadOS.