### PR TITLE
Fix infinite loop for duplicate on macOS

### DIFF
--- a/Sources/CodeEditorView/CodeEditing.swift
+++ b/Sources/CodeEditorView/CodeEditing.swift
@@ -118,7 +118,7 @@ public struct CodeEditingCommandsView: View {
 extension CodeView: CodeEditorActions {
 
 #if os(macOS)
-  @objc public func duplicate(_ sender: Any?) { duplicate(sender) }
+  @objc public func duplicate(_ sender: Any?) { duplicate() }
 #elseif os(iOS) || os(visionOS)
   @objc public override func duplicate(_ sender: Any?) { duplicate() }
 #endif


### PR DESCRIPTION
Corrects the infinite loop when using duplicate on the CodeView on macOS (https://github.com/mchakravarty/CodeEditorView/issues/126)