### PR TITLE
fix: do not update `textView.text` during updating UI

### DIFF
--- a/Sources/CodeEditorView/CodeEditor.swift
+++ b/Sources/CodeEditorView/CodeEditor.swift
@@ -645,7 +645,9 @@ extension CodeEditor: UIViewRepresentable {
       if language.languageService !== codeView.language.languageService {
         (codeView.optCodeStorage?.delegate as? CodeStorageDelegate)?.skipNextChangeNotificationToLanguageService = true
       }
-      codeView.text = text
+      Task { @MainActor in
+        codeView.text = text
+      }
 //      // FIXME: Stupid hack to force redrawing when the language doesn't change. (A language change already forces
 //      // FIXME: redrawing.)
 //      if language == codeView.language {


### PR DESCRIPTION
fixes #132

I tested on Swift Playground 4.6.4 (iOS 18 SDK & Swift 6.0.2) on iPadOS 18.5.

https://github.com/user-attachments/assets/733bc67f-ee25-4113-bc0e-65b50f6e207b

