### PR TITLE
Fix UTF-16 indexing for emoji characters in code storage

### DIFF
--- a/Sources/CodeEditorView/CodeStorageDelegate.swift
+++ b/Sources/CodeEditorView/CodeStorageDelegate.swift
@@ -804,7 +804,9 @@ extension CodeStorageDelegate {
 
 
     let string             = codeStorage.string,
-        char               = string.utf16[string.index(string.startIndex, offsetBy: index)],
+        utf16View          = string.utf16,
+        utf16Index         = utf16View.index(utf16View.startIndex, offsetBy: index),
+        char               = utf16View[utf16Index],
         previousTypedToken = lastTypedToken,
         currentTypedToken  = codeStorage.tokenOnly(at: index)
 


### PR DESCRIPTION
Pressing Enter at the end of a document containing emoji characters (e.g., "flag: 🏁 fumble") causes a crash with "String index is out of bounds" in tokenCompletion(for:at:).

The index parameter is a UTF-16 offset (from NSRange), but the code was treating it as a Character offset: string.utf16[string.index(string.startIndex, offsetBy: index)]

Emojis like 🏁 are 1 Character but 2 UTF-16 code units, causing the index to exceed the string's character count.

I ran into this while building an app with your amazing library, thanks for your work!